### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-KEYWORD1    LDC1612
+KEYWORD1	LDC1612
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-KEYWORD2    init
-KEYWORD2    read_sensor_infomation
-KEYWORD2    single_channel_config
-KEYWORD2    LDC1612_mutiple_channel_config
+KEYWORD2	init
+KEYWORD2	read_sensor_infomation
+KEYWORD2	single_channel_config
+KEYWORD2	LDC1612_mutiple_channel_config
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords